### PR TITLE
Changing the logPretty function to use log.Printf instead of fmt.Printf

### DIFF
--- a/util.go
+++ b/util.go
@@ -29,5 +29,5 @@ func logPretty(x interface{}) {
 	_, file, line, _ := runtime.Caller(1)
 	lineNo := strconv.Itoa(line)
 	s := file + ":" + lineNo + ": %# v\n"
-	pretty.Printf(s, x)
+	pretty.Logf(s, x)
 }


### PR DESCRIPTION
A very, very small, trivial PR:

Since the default behavior of `log.Printf` is the same as `fmt.Printf` (prints to stdout), this commit doesn't actually change any functionality. However, Go's internal `log` package is much more customizable (log to a file if you want, etc) than a plain `fmt.Printf`.
