### PR TITLE
Fix syntax in the usage example.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,7 @@ Example Usage:
 		//
 		n0, _ := db.CreateNode(neoism.Props{"name": kirk})
 		defer n0.Delete()  // Deferred clean up
+		n0.AddLabel("Person") // Add a label
 		//
 		// Create a node with a Cypher query
 		//
@@ -84,7 +85,7 @@ Example Usage:
 			},
 			&neoism.CypherQuery{
 				Statement: `
-					MATCH n:Person
+					MATCH (n:Person)
 					WHERE n.name = {name}
 					DELETE n
 				`,


### PR DESCRIPTION
Hi there!

I spotted an error in the usage example (doc.go): the second cleanup is not deleting the node because parentheses are missing around the matching in the Cypher query. This pull request fixes this issue.

I also added a label "Person" manually to the first node so that the two methods for creating a node produce the same output.

Hope this helps!

Cheers
