### PR TITLE
Add db references to Rels[] results

### DIFF
--- a/node.go
+++ b/node.go
@@ -142,6 +142,9 @@ func (n *Node) getRels(uri string, types ...string) (Rels, error) {
 	if resp.Status() != 200 {
 		return rels, ne
 	}
+	for _, rel := range rels {
+		rel.Db = n.Db
+	}
 	return rels, nil // Success!
 }
 


### PR DESCRIPTION
When iterating over a Rels slice, calling rel.Delete() would cause a panic because rel.Db was never set (as it is when calling node.Relationship(id)).

I've set the Db reference on each relationship before returning the Rels.

Thanks for the good work!
