### PR TITLE
Connect to graphene DB

### DIFF
--- a/database.go
+++ b/database.go
@@ -51,7 +51,7 @@ func Connect(uri string) (*Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	if resp.Status() != 200 || db.Version == "" {
+	if resp.Status() != 200 {
 		log.Println("Status " + strconv.Itoa(resp.Status()) + " trying to connect to " + uri)
 		return nil, InvalidDatabase
 	}


### PR DESCRIPTION
Hello there,

When I try to connect to Graphene DB I get the following output : 

``` log
14:40:14.646490 database.go:55: Status 200 trying to connect to http://app****:****@app***.sb02.stations.graphenedb.com:24783
panic: Invalid database.  Check URI.
```

I think GrapheneDB does not send the version back which is why it fails there.

Cheers.
