### PR TITLE
Add basic test for working external service

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jmcvetta/randutil"
 	"log"
 	"testing"
+	"os"
 )
 
 func connectTest(t *testing.T) *Database {
@@ -97,4 +98,15 @@ func TestConnectInvalidUrl(t *testing.T) {
 	//
 	_, err = Connect("http://localhost:7474")
 	assert.Equal(t, InvalidDatabase, err)
+}
+
+func TestConnectSecureUrl(t *testing.T) {
+	if url := os.Getenv("NEO4J_URL"); url != "" {
+		_, err := Connect(url)
+		if err != nil {
+			t.Fatal("Cannot connect to a secure url")
+		}
+	} else {
+		t.Skip("Skipping the test as no $NEO4J_URL is exported")
+	}
 }


### PR DESCRIPTION
Run it like this : `export NEO4J_URL="url"; go test -v -run TestConnectSecureUrl`

Creating a basic neo4j server is free on [graphenedb.com](http://www.graphenedb.com/pricing.html).

It's not optimal as it relies on the url defined and the service but it helps testing :)

Cheers !
#46
