### PR TITLE
Implement Error interface for TxError and move to error.go

### DIFF
--- a/error.go
+++ b/error.go
@@ -15,6 +15,9 @@ var (
 	InvalidDatabase = errors.New("Invalid database.  Check URI.")
 	NotAllowed      = errors.New("Operation not allowed.")
 	NotFound        = errors.New("Cannot find in database.")
+	// A TxQueryError is returned when there is an error with one of the Cypher
+	// queries inside a transaction, but not with the transaction itself.
+	TxQueryError = errors.New("Error with a query inside a transaction.")
 )
 
 // A NeoError is populated by api calls when there is an error.
@@ -28,4 +31,17 @@ type NeoError struct {
 // Error returns the error message supplied by the server.
 func (ne NeoError) Error() string {
 	return ne.Message
+}
+
+// A TxError is an error with one of the statements submitted in a transaction,
+// but not with the transaction itself.
+type TxError struct {
+	Code    string
+	Status  string
+	Message string
+}
+
+// Error returns the error message supplied by the server.
+func (t *TxError) Error() string {
+	return t.Message
 }

--- a/transaction.go
+++ b/transaction.go
@@ -18,22 +18,6 @@ type Tx struct {
 	Expires    string // Cannot unmarshall into time.Time :(
 }
 
-// A TxQueryError is returned when there is an error with one of the Cypher
-// queries inside a transaction, but not with the transaction itself.
-var TxQueryError = errors.New("Error with a query inside a transaction.")
-
-// A TxError is an error with one of the statements submitted in a transaction,
-// but not with the transaction itself.
-type TxError struct {
-	Code    string
-	Status  string
-	Message string
-}
-
-func (t *TxError) Error() string {
-	return t.Message
-}
-
 type txRequest struct {
 	Statements []*CypherQuery `json:"statements"`
 }


### PR DESCRIPTION
This PR implements the `Error` interface for type `TxError`, per #57 by @bruth; and moves types `TxError` and `TxQueryError` to file `error.go`.
