### PR TITLE
run the tests with neo4j 2.2.0 and NEO4J_URL env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,9 @@ before_install:
   - sh start-neo4j.sh
 
 env:
-  - NEO4J_VERSION="2.1.2"
+  global:
+    - NEO4J_VERSION="2.2.0"
+    - NEO4J_URL=http://localhost:7474/db/data/
+
+script:
+  - go test -v

--- a/connect.go
+++ b/connect.go
@@ -9,6 +9,7 @@ package neoism
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/jmcvetta/napping"
 )
@@ -23,12 +24,17 @@ func Connect(uri string) (*Database, error) {
 			Header: &h,
 		},
 	}
-	parsedUrl, err := url.Parse(uri)
+
+	// trailing slash is important, check if it's not there and add it
+	if !strings.HasSuffix(uri, "/") {
+		uri += "/"
+	}
+	parsedURL, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
-	if parsedUrl.User != nil {
-		db.Session.Userinfo = parsedUrl.User
+	if parsedURL.User != nil {
+		db.Session.Userinfo = parsedURL.User
 	}
-	return connectWithRetry(db, parsedUrl, 0)
+	return connectWithRetry(db, parsedURL, 0)
 }

--- a/database.go
+++ b/database.go
@@ -65,7 +65,7 @@ func PropertyKeys(db *Database) ([]string, error) {
 	propertyKeys := []string{}
 	ne := NeoError{}
 
-	uri := db.Url + "/" + "propertykeys"
+	uri := db.Url + "propertykeys"
 	resp, err := db.Session.Get(uri, nil, &propertyKeys, &ne)
 	if err != nil {
 		return propertyKeys, err

--- a/start-neo4j.sh
+++ b/start-neo4j.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-DIR="neo4j-community-2.1.2"
+DIR="neo4j-community-2.2.0"
 FILE="$DIR-unix.tar.gz"
 
 wget "http://dist.neo4j.org/$FILE"
 tar zxf $FILE
+# Disable authentication, if we enable it, we have to change the default neo4j user
+# password and then run all the tests with a different one
+sed -i "s/auth_enabled\=true/auth_enabled\=false/g" $DIR/conf/neo4j-server.properties
 $DIR/bin/neo4j start
 sleep 3


### PR DESCRIPTION
The tests are now running with the latest neo4j version. They will now only run if a environment variable is set. Everybody can run the tests now in  his own environment. They previously only connected to `localhost`

For proper test builds, travis must be configured with 1 Environment variable now, which are
- NEO4J_URL
