### PR TITLE
Added support for https connections

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -7,10 +7,16 @@
 package neoism
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/url"
 
+	"crypto/x509"
+	"errors"
 	"github.com/jmcvetta/napping"
+	"io/ioutil"
+	"log"
+	"os"
 )
 
 // Connect setups parameters for the Neo4j server
@@ -18,8 +24,32 @@ import (
 func Connect(uri string) (*Database, error) {
 	h := http.Header{}
 	h.Add("User-Agent", "neoism")
+
+	tcc := &tls.Config{}
+
+	caCertFile := os.Getenv("CACERTSFILE")
+	if caCertFile != "" {
+		log.Println("CA Cert file was specified, appending it into the Cert pool...")
+		caCert, err := ioutil.ReadFile(caCertFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		ok := caCertPool.AppendCertsFromPEM(caCert)
+		if !ok {
+			return nil, errors.New("Unable to append the certificate to the CA certs pool.")
+		}
+
+		tcc.RootCAs = caCertPool
+	} else {
+		tcc.InsecureSkipVerify = true
+	}
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: tcc}}
+
 	db := &Database{
 		Session: &napping.Session{
+			Client: client,
 			Header: &h,
 		},
 	}


### PR DESCRIPTION
Added support for https connections with either skipping the cert check or passing the cert file in an env variable.

This is especially useful as from neo4j 2.2 as the default is to run over https.

Unfortunately the Go https implementation does not accept the neo4j cert file that is automatically generated during the neo4j installation so you still have to create a key and cert file manually.
