### PR TITLE
Update to Testify assert package

### DIFF
--- a/cypher_test.go
+++ b/cypher_test.go
@@ -6,7 +6,7 @@ package neoism
 
 import (
 	"fmt"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )

--- a/database_test.go
+++ b/database_test.go
@@ -34,7 +34,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/jmcvetta/randutil"
 )
 

--- a/doc.go
+++ b/doc.go
@@ -100,6 +100,6 @@ package neoism
 
 // Imports required for tests - so they work with "go get".
 import (
-	_ "github.com/bmizerany/assert"
+	_ "github.com/stretchr/testify/assert"
 	_ "github.com/jmcvetta/randutil"
 )

--- a/node_index_test.go
+++ b/node_index_test.go
@@ -6,7 +6,7 @@ package neoism
 
 import (
 	"fmt"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )
@@ -92,7 +92,7 @@ func TestListLegacyNodeIndexes(t *testing.T) {
 			valid = true
 		}
 	}
-	assert.T(t, valid, "Newly created Index not found in listing of all Indexes.")
+	assert.True(t, valid, "Newly created Index not found in listing of all Indexes.")
 }
 
 // 18.9.5. Add node to index
@@ -207,9 +207,9 @@ func TestFindNodeByExactMatch(t *testing.T) {
 	// This query should have returned a map containing just two nodes, n1 and n0.
 	assert.Equal(t, len(nodes), 2)
 	_, present := nodes[n0.Id()]
-	assert.Tf(t, present, "Find() failed to return node with id "+strconv.Itoa(n0.Id()))
+	assert.True(t, present, "Find() failed to return node with id "+strconv.Itoa(n0.Id()))
 	_, present = nodes[n1.Id()]
-	assert.Tf(t, present, "Find() failed to return node with id "+strconv.Itoa(n1.Id()))
+	assert.True(t, present, "Find() failed to return node with id "+strconv.Itoa(n1.Id()))
 }
 
 // 18.9.10. Find node by query
@@ -242,12 +242,12 @@ func TestFindNodeByQuery(t *testing.T) {
 		t.Error(err)
 	}
 	// Confirm
-	assert.Equalf(t, len(nodes0), 1, "Query should have returned only one Node.")
+	assert.Equal(t, len(nodes0), 1, "Query should have returned only one Node.")
 	_, present := nodes0[n0.Id()]
-	assert.Tf(t, present, "Query() failed to return node with id "+strconv.Itoa(n0.Id()))
-	assert.Equalf(t, len(nodes1), 2, "Query should have returned exactly 2 Nodes.")
+	assert.True(t, present, "Query() failed to return node with id "+strconv.Itoa(n0.Id()))
+	assert.Equal(t, len(nodes1), 2, "Query should have returned exactly 2 Nodes.")
 	_, present = nodes1[n0.Id()]
-	assert.Tf(t, present, "Query() failed to return node with id "+strconv.Itoa(n0.Id()))
+	assert.True(t, present, "Query() failed to return node with id "+strconv.Itoa(n0.Id()))
 	_, present = nodes1[n1.Id()]
-	assert.Tf(t, present, "Query() failed to return node with id "+strconv.Itoa(n1.Id()))
+	assert.True(t, present, "Query() failed to return node with id "+strconv.Itoa(n1.Id()))
 }

--- a/node_test.go
+++ b/node_test.go
@@ -9,8 +9,8 @@
 package neoism
 
 import (
-	"github.com/bmizerany/assert"
 	"github.com/jmcvetta/randutil"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -56,7 +56,7 @@ func TestCreateNodeWithProperties(t *testing.T) {
 	}
 	// Confirm properties
 	props1, _ := n0.Properties()
-	assert.Equalf(t, props0, props1, "Node properties not as expected")
+	assert.Equal(t, props0, props1, "Node properties not as expected")
 }
 
 // 18.4.2. Create Node with properties
@@ -132,7 +132,7 @@ func TestGetNode(t *testing.T) {
 		t.Error(err)
 	}
 	// Confirm nodes are the same
-	assert.Equalf(t, n0.Id(), n1.Id(), "Nodes do not have same ID")
+	assert.Equal(t, n0.Id(), n1.Id(), "Nodes do not have same ID")
 }
 
 // 18.4.4. Get non-existent node
@@ -179,7 +179,7 @@ func TestDeleteNodeWithRelationships(t *testing.T) {
 	n0.Relate("knows", n1.Id(), Props{})
 	// Attempt to delete node without deleting relationship
 	err := n0.Delete()
-	assert.Equalf(t, err, CannotDelete, "Should not be possible to delete node with relationship.")
+	assert.Equal(t, err, CannotDelete, "Should not be possible to delete node with relationship.")
 }
 
 // 18.7.1. Set property on node
@@ -197,8 +197,8 @@ func TestSetPropertyOnNode(t *testing.T) {
 	// Confirm
 	props, _ := n0.Properties()
 	checkVal, present := props[key]
-	assert.Tf(t, present, "Expected property key not found")
-	assert.Tf(t, checkVal == value, "Expected property value not found")
+	assert.True(t, present, "Expected property key not found")
+	assert.True(t, checkVal == value, "Expected property value not found")
 }
 
 // 18.7.1. Set property on node
@@ -229,7 +229,7 @@ func TestUpdatePropertyOnNode(t *testing.T) {
 	}
 	// Confirm
 	checkProps, _ := n0.Properties()
-	assert.Equalf(t, props1, checkProps, "Did not recover expected properties after updating with SetProperties().")
+	assert.Equal(t, props1, checkProps, "Did not recover expected properties after updating with SetProperties().")
 }
 
 // 18.7.3. Get properties for node
@@ -244,7 +244,7 @@ func TestGetPropertiesForNode(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, props, checkProps, "Did not return expected properties.")
+	assert.Equal(t, props, checkProps, "Did not return expected properties.")
 }
 
 //
@@ -279,7 +279,7 @@ func TestDeleteAllPropertiesFromNode(t *testing.T) {
 	}
 	// Confirm deletion
 	checkProps, _ := n0.Properties()
-	assert.Equalf(t, Props{}, checkProps, "Properties should be empty after call to DeleteProperties()")
+	assert.Equal(t, Props{}, checkProps, "Properties should be empty after call to DeleteProperties()")
 	n0.Delete()
 	err = n0.DeleteProperties()
 	assert.Equal(t, NotFound, err)
@@ -300,7 +300,7 @@ func TestDeleteNamedPropertyFromNode(t *testing.T) {
 	}
 	// Confirm
 	checkProps, _ := n0.Properties()
-	assert.Equalf(t, props0, checkProps, "Failed to remove named property with DeleteProperty().")
+	assert.Equal(t, props0, checkProps, "Failed to remove named property with DeleteProperty().")
 	//
 	// Delete non-existent property
 	//
@@ -323,7 +323,7 @@ func TestNodeProperty(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, value, "bar", "Incorrect value when getting single property.")
+	assert.Equal(t, value, "bar", "Incorrect value when getting single property.")
 	//
 	// Check Not Found
 	//

--- a/rel_index_test.go
+++ b/rel_index_test.go
@@ -5,7 +5,7 @@
 package neoism
 
 import (
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/relationship_test.go
+++ b/relationship_test.go
@@ -5,7 +5,7 @@
 package neoism
 
 import (
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"sort"
 	"testing"
 )
@@ -40,10 +40,10 @@ func TestCreateRelationship(t *testing.T) {
 	// Confirm relationship exists on both nodes
 	rels, _ := n0.Outgoing("knows")
 	_, present := rels.Map()[r0.Id()]
-	assert.Tf(t, present, "Outgoing relationship not present on origin node.")
+	assert.True(t, present, "Outgoing relationship not present on origin node.")
 	rels, _ = n1.Incoming("knows")
 	_, present = rels.Map()[r0.Id()]
-	assert.Tf(t, present, "Incoming relationship not present on destination node.")
+	assert.True(t, present, "Incoming relationship not present on destination node.")
 }
 
 // 18.5.3. Create a relationship with properties
@@ -60,7 +60,7 @@ func TestCreateRelationshipWithProperties(t *testing.T) {
 	}
 	// Confirm relationship was created with specified properties.
 	props1, _ := r0.Properties()
-	assert.Equalf(t, props0, props1, "Properties queried from relationship do not match properties it was created with.")
+	assert.Equal(t, props0, props1, "Properties queried from relationship do not match properties it was created with.")
 }
 
 // 18.5.4. Delete relationship
@@ -77,7 +77,7 @@ func TestDeleteRelationship(t *testing.T) {
 	// Delete and confirm
 	r0.Delete()
 	_, err = db.Relationship(r0.Id())
-	assert.Equalf(t, err, NotFound, "Should not be able to Get() a deleted relationship.")
+	assert.Equal(t, err, NotFound, "Should not be able to Get() a deleted relationship.")
 }
 
 // 18.5.5. Get all properties on a relationship
@@ -95,7 +95,7 @@ func TestGetAllPropertiesOnRelationship(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, props0, props1, "Properties queried from relationship do not match properties it was created with.")
+	assert.Equal(t, props0, props1, "Properties queried from relationship do not match properties it was created with.")
 }
 
 // 18.5.6. Set all properties on a relationship
@@ -112,7 +112,7 @@ func TestSetAllPropertiesOnRelationship(t *testing.T) {
 	r0.SetProperties(props1)
 	// Confirm
 	checkProps, _ := r0.Properties()
-	assert.Equalf(t, checkProps, props1, "Failed to set all properties on relationship")
+	assert.Equal(t, checkProps, props1, "Failed to set all properties on relationship")
 }
 
 // 18.5.7. Get single property on a relationship
@@ -129,7 +129,7 @@ func TestGetSinglePropertyOnRelationship(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, value, "bar", "Incorrect value when getting single property.")
+	assert.Equal(t, value, "bar", "Incorrect value when getting single property.")
 }
 
 // 18.5.8. Set single property on a relationship
@@ -145,7 +145,7 @@ func TestSetSinglePropertyOnRelationship(t *testing.T) {
 	// Confirm
 	expected := Props{"foo": "bar"}
 	props, _ := r0.Properties()
-	assert.Equalf(t, props, expected, "Failed to set single property on relationship.")
+	assert.Equal(t, props, expected, "Failed to set single property on relationship.")
 }
 
 // 18.5.9. Get all relationships
@@ -163,10 +163,10 @@ func TestGetAllRelationships(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 3, "Wrong number of relationships")
+	assert.Equal(t, len(rels), 3, "Wrong number of relationships")
 	for _, r := range []*Relationship{r0, r1, r2} {
 		_, present := rels.Map()[r.Id()]
-		assert.Tf(t, present, "Missing expected relationship")
+		assert.True(t, present, "Missing expected relationship")
 	}
 }
 
@@ -185,9 +185,9 @@ func TestGetIncomingRelationships(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 1, "Wrong number of relationships")
+	assert.Equal(t, len(rels), 1, "Wrong number of relationships")
 	_, present := rels.Map()[r1.Id()]
-	assert.Tf(t, present, "Missing expected relationship")
+	assert.True(t, present, "Missing expected relationship")
 }
 
 // 18.5.11. Get outgoing relationships
@@ -205,10 +205,10 @@ func TestGetOutgoingRelationships(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 2, "Wrong number of relationships")
+	assert.Equal(t, len(rels), 2, "Wrong number of relationships")
 	for _, r := range []*Relationship{r0, r2} {
 		_, present := rels.Map()[r.Id()]
-		assert.Tf(t, present, "Missing expected relationship")
+		assert.True(t, present, "Missing expected relationship")
 	}
 }
 
@@ -228,18 +228,18 @@ func TestGetTypedRelationships(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 1, "Wrong number of relationships")
+	assert.Equal(t, len(rels), 1, "Wrong number of relationships")
 	_, present := rels.Map()[r0.Id()]
-	assert.Tf(t, present, "Missing expected relationship")
+	assert.True(t, present, "Missing expected relationship")
 	// Check two types of relationship together
 	rels, err = n0.Relationships(relType0, relType1)
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 2, "Wrong number of relationships")
+	assert.Equal(t, len(rels), 2, "Wrong number of relationships")
 	for _, r := range []*Relationship{r0, r1} {
 		_, present := rels.Map()[r.Id()]
-		assert.Tf(t, present, "Missing expected relationship")
+		assert.True(t, present, "Missing expected relationship")
 	}
 }
 
@@ -252,7 +252,7 @@ func TestGetRelationshipsOnNodeWithoutRelationships(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equalf(t, len(rels), 0, "Node with no relationships should return empty slice of relationships")
+	assert.Equal(t, len(rels), 0, "Node with no relationships should return empty slice of relationships")
 }
 
 // 18.6.1. Get relationship types
@@ -279,7 +279,7 @@ func TestGetRelationshipTypes(t *testing.T) {
 		t.Error(err)
 	}
 	for _, rt := range relTypes {
-		assert.Tf(t, sort.SearchStrings(foundRelTypes, rt) < len(foundRelTypes),
+		assert.True(t, sort.SearchStrings(foundRelTypes, rt) < len(foundRelTypes),
 			"Could not find expected relationship type: "+rt)
 	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -6,7 +6,7 @@ package neoism
 
 import (
 	"fmt"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -6,7 +6,7 @@ package neoism
 
 import (
 	"encoding/json"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 )
@@ -170,7 +170,7 @@ func TestTxBadQuery(t *testing.T) {
 	tx.Rollback() // Else cleanup will hang til Tx times out
 	assert.Equal(t, TxQueryError, err)
 	numErr := len(tx.Errors)
-	assert.T(t, numErr == 1, "Expected one tx error, got "+strconv.Itoa(numErr))
+	assert.True(t, numErr == 1, "Expected one tx error, got "+strconv.Itoa(numErr))
 }
 
 func TestTxQuery(t *testing.T) {


### PR DESCRIPTION
From jmcvetta/napping#32 and jmcvetta/randutil#4, I'm updating across dependent packages to a newer assert package from Testify. It should solve a build error that will provide compatibility with Nut's vendoring system.