### PR TITLE
fix build against recent neo4j version (2.3.1)

### DIFF
--- a/cypher_test.go
+++ b/cypher_test.go
@@ -49,6 +49,7 @@ func TestCypherParameters(t *testing.T) {
 			MATCH path = (n)-[r]->(m)
 			WHERE m.name = {name}
 			RETURN id(n), id(r), id(m)
+			ORDER by id(n), id(r), id(m)
 		`,
 		Parameters: map[string]interface{}{
 			"startName": "I",


### PR DESCRIPTION
This fixes one of the two tests that fail in circleci due to running with version 2.3.1 of neo4j.
EDIT: this PR now fixes all known issues, allowing the tests to also complete against newer versions of neo4j.  This fixes the build in circleci.