### PR TITLE
Allow the caller to supply their own http client.

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -17,11 +17,18 @@ import (
 // Connect setups parameters for the Neo4j server
 // and calls ConnectWithRetry()
 func Connect(uri string) (*Database, error) {
+	return ConnectWithClient(uri, nil)
+}
+
+// ConnectWithClient setups parameters for the Neo4j server
+// and calls ConnectWithRetry() with a given http.Client
+func ConnectWithClient(uri string, client *http.Client) (*Database, error) {
 	h := http.Header{}
 	h.Add("User-Agent", "neoism")
 	db := &Database{
 		Session: &napping.Session{
 			Header: &h,
+			Client: client,
 		},
 	}
 


### PR DESCRIPTION
This is useful for example if the caller wants to supply their own http client with a custom transport (in my case, one that connects via a socks5 proxy)
