### PR TITLE
Permit custom http client

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -14,15 +14,33 @@ import (
 	"gopkg.in/jmcvetta/napping.v3"
 )
 
-// Connect setups parameters for the Neo4j server
-// and calls ConnectWithRetry()
-func Connect(uri string) (*Database, error) {
+// option is a type alias for a function that takes a pointer to a Database.
+// Used for functional configuration of our client.
+type option func(*Database)
+
+// WithClient is a configuration function that allows users of this library to
+// supply their own http.Client. This is required if they want to use a self
+// signed TLS certificate for example.
+func WithClient(client *http.Client) option {
+	return func(db *Database) {
+		db.Session.Client = client
+	}
+}
+
+// Connect sets up our client for connecting to the Neo4j server and calls
+// ConnectWithRetry()
+func Connect(uri string, options ...option) (*Database, error) {
 	h := http.Header{}
 	h.Add("User-Agent", "neoism")
 	db := &Database{
 		Session: &napping.Session{
 			Header: &h,
 		},
+	}
+
+	// apply our configuration functions
+	for _, opt := range options {
+		opt(db)
 	}
 
 	// trailing slash is important, check if it's not there and add it

--- a/connect.go
+++ b/connect.go
@@ -14,14 +14,10 @@ import (
 	"gopkg.in/jmcvetta/napping.v3"
 )
 
-// option is a type alias for a function that takes a pointer to a Database.
-// Used for functional configuration of our client.
-type option func(*Database)
-
 // WithClient is a configuration function that allows users of this library to
 // supply their own http.Client. This is required if they want to use a self
 // signed TLS certificate for example.
-func WithClient(client *http.Client) option {
+func WithClient(client *http.Client) func(*Database) {
 	return func(db *Database) {
 		db.Session.Client = client
 	}
@@ -29,7 +25,7 @@ func WithClient(client *http.Client) option {
 
 // Connect sets up our client for connecting to the Neo4j server and calls
 // ConnectWithRetry()
-func Connect(uri string, options ...option) (*Database, error) {
+func Connect(uri string, options ...func(*Database)) (*Database, error) {
 	h := http.Header{}
 	h.Add("User-Agent", "neoism")
 	db := &Database{

--- a/cypher_test.go
+++ b/cypher_test.go
@@ -166,7 +166,7 @@ func TestCypher(t *testing.T) {
 	}
 	result := []resultStruct{}
 	cq := CypherQuery{
-		Statement: "start x = node(" + strconv.Itoa(n0.Id()) + ") match x -[r]-> n return type(r), n.name, n.age",
+		Statement: "start x = node(" + strconv.Itoa(n0.Id()) + ") match (x) -[r]-> (n) return type(r), n.name, n.age",
 		Result:    &result,
 	}
 	err := db.Cypher(&cq)
@@ -211,7 +211,7 @@ func TestCypherComment(t *testing.T) {
 	stmt := `
 		START x = NODE(%d)
 		// This is a comment
-		MATCH x -[r]-> n
+		MATCH (x) -[r]-> (n)
 		// This is another comment
 		RETURN TYPE(r), n.name, n.age
 		`
@@ -319,7 +319,7 @@ func TestCypherBatch(t *testing.T) {
 			Statement: `
 				MATCH (a:Person), (b:Person)
 				WHERE a.name = 'Mr Spock' AND b.name = 'Mr Sulu'
-				CREATE a-[r:Knows]->b
+				CREATE (a)-[r:Knows]->(b)
 				RETURN r
 			`,
 			Result: &r2,

--- a/database_test.go
+++ b/database_test.go
@@ -30,12 +30,14 @@ package neoism
 
 import (
 	"log"
+	"net/http"
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/jmcvetta/randutil"
+	"github.com/stretchr/testify/assert"
 )
 
 // neo4jUrl is global in order for TestConnect() to work when NEO4J_URL is set.
@@ -55,7 +57,6 @@ func connectTest(t *testing.T) *Database {
 	}
 	return db
 }
-
 
 func cleanup(t *testing.T, db *Database) {
 	qs := []*CypherQuery{

--- a/database_test.go
+++ b/database_test.go
@@ -34,7 +34,6 @@ import (
 	"os"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/jmcvetta/randutil"
 	"github.com/stretchr/testify/assert"
@@ -129,9 +128,7 @@ func TestConnectCustomClient(t *testing.T) {
 		neo4jUrl = "http://neo4j:foobar@localhost:7474/db/data/"
 	}
 
-	client := &http.Client{
-		Timeout: time.Second * 10,
-	}
+	client := &http.Client{}
 
 	db, err := Connect(neo4jUrl, WithClient(client))
 	assert.Nil(t, err)

--- a/database_test.go
+++ b/database_test.go
@@ -121,6 +121,23 @@ func TestConnectIncompleteUrl(t *testing.T) {
 	}
 }
 
+func TestConnectCustomClient(t *testing.T) {
+	neo4jUrl = os.Getenv("NEO4J_URL")
+	if neo4jUrl == "" {
+		// As of Neo4j v2.2.x, authentication is enabled by default.
+		neo4jUrl = "http://neo4j:foobar@localhost:7474/db/data/"
+	}
+
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	db, err := Connect(neo4jUrl, WithClient(client))
+	assert.Nil(t, err)
+
+	assert.Equal(t, client, db.Session.Client)
+}
+
 func TestPropertyKeys(t *testing.T) {
 	db := connectTest(t)
 	defer cleanup(t, db)
@@ -170,4 +187,3 @@ func TestPropertyKeys(t *testing.T) {
 		}
 	}
 }
-

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -51,7 +51,7 @@ func TestTxBegin(t *testing.T) {
 		Statement: `
 				MATCH (a:Person), (b:Person)
 				WHERE a.name = "James T Kirk" AND b.name = "Dr McCoy"
-				CREATE a-[r:Commands]->b
+				CREATE (a)-[r:Commands]->(b)
 				RETURN a.name, type(r), b
 			`,
 		Parameters: map[string]interface{}{


### PR DESCRIPTION
This PR borrows from #97 in that it allows users of this library to supply their own http.Client instance, but utilises a functional option style of configuration meaning we can leave the `Connect` method unchanged for the default case, but permit a custom client to be passed via a variadic second argument.

Our reason for requiring this was to use the HTTPS connector with a self signed certificate where we required creating a custom client with the same certificate in order to communicate from our client to the server.

This PR also tweaked a couple of lines of Cypher in order to have the tests pass on Neo4j 3.2.x .