### PR TITLE
Removing test.XXX Flags (Closing #94) when importing this library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ notificaitons:
     on_success: change
     on_failure: always
 before_script:
-  - go get -v github.com/bmizerany/assert
   - go get -v github.com/jmcvetta/randutil
+  - go get -v github.com/stretchr/testify/assert
 #
 # Lines below copied from # https://github.com/versae/neo4j-rest-client/blob/master/.travis.yml
 #

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Tested against Neo4j 2.2.4 and Go 1.4.1.
 ## Development
 
 ```
-go get -v github.com/jmcvetta/neoism
+go get -t -v github.com/jmcvetta/neoism
 ```
 
 

--- a/doc.go
+++ b/doc.go
@@ -97,9 +97,3 @@ Example Usage:
 	}
 */
 package neoism
-
-// Imports required for tests - so they work with "go get".
-import (
-	_ "github.com/stretchr/testify/assert"
-	_ "github.com/jmcvetta/randutil"
-)


### PR DESCRIPTION
Hi :)
this PR closes issue nr #94 . It simply removes the testing dependencies from the doc.go document. 

Before [go1.2rc2](https://github.com/golang/go/commit/5dde7ccecf22a345535721c78a34879755de1fc0) this would be necessary in order to get them with `go get`. However testing depencies can be gathered using the `-t` flag.

Thanks 